### PR TITLE
fixed issue with generate_data_key ignoring key size param when setting KeySpec default

### DIFF
--- a/lib/ex_aws/kms.ex
+++ b/lib/ex_aws/kms.ex
@@ -196,10 +196,13 @@ defmodule ExAws.KMS do
     |> Map.merge(%{
           "Action"  => "GenerateDataKey",
           "Version" => @version,
-          "KeyId"   => key_id,
-          "KeySpec" => opts[:key_spec] || "AES_256"})
+          "KeyId"   => key_id})
 
-    request(:generate_data_key, query_params)
+    if !Map.has_key?(query_params, "KeySpec") and !Map.has_key?(query_params, "NumberOfBytes") do
+      request(:generate_data_key, Map.put(query_params, "KeySpec", "AES_256"))
+    else
+      request(:generate_data_key, query_params)
+    end
   end
 
   @doc "Generate a data key without plaintext"

--- a/test/lib/kms_test.exs
+++ b/test/lib/kms_test.exs
@@ -247,7 +247,6 @@ defmodule ExAws.KMSTest do
                                          "KeyId"             => "key-id",
                                          "EncryptionContext" => %{"key" => "value"},
                                          "GrantTokens"       => ["token"],
-                                         "KeySpec"           => "AES_128",
                                          "NumberOfBytes"     => 16},
                                  headers: [{"x-amz-target", "TrentService.GenerateDataKey"},
                                            {"content-type", "application/x-amz-json-1.0"}],
@@ -255,7 +254,7 @@ defmodule ExAws.KMSTest do
                                  parser: _,
                                  path: "/",
                                  service: :kms,
-                                 stream_builder: nil} = ExAws.KMS.generate_data_key("key-id", encryption_context: %{ "key" => "value" }, grant_tokens: ["token"], key_spec: "AES_128", number_of_bytes: 16)
+                                 stream_builder: nil} = ExAws.KMS.generate_data_key("key-id", encryption_context: %{ "key" => "value" }, grant_tokens: ["token"], number_of_bytes: 16)
   end
 
   test "GenerateDataKeyWithoutPlaintext" do


### PR DESCRIPTION
Per the [aws docs](https://docs.aws.amazon.com/cli/latest/reference/kms/generate-data-key.html), you can specify _either_ `KeySpec` _or_ `NumberOfBytes` but not both (trying to specify both on the command line results in "Please specify either number of bytes or key spec.").

As such, `KeySpec` should *not* take a default value unless `NumberOfBytes` is not set.  Prior to this fix, there was no way to not set `KeySpec` (nil / empty string both resulted in error results from the API) - which meant that it was always set - which meant there was no way to specify `NumberOfBytes`.

The tests were updated - there should be no valid cases where both `KeySpec` and `NumberOfBytes` are both set in the request.