### PR TITLE
GenerateDataKeyWithoutPlaintext now does not send KeySpec when sending NumberOfBytes

### DIFF
--- a/lib/ex_aws/kms.ex
+++ b/lib/ex_aws/kms.ex
@@ -298,11 +298,14 @@ defmodule ExAws.KMS do
       |> Map.merge(%{
         "Action" => "GenerateDataKeyWithoutPlaintext",
         "Version" => @version,
-        "KeyId" => key_id,
-        "KeySpec" => opts[:key_spec] || "AES_256"
+        "KeyId" => key_id
       })
 
-    request(:generate_data_key_without_plaintext, query_params)
+    if !Map.has_key?(query_params, "KeySpec") and !Map.has_key?(query_params, "NumberOfBytes") do
+      request(:generate_data_key_without_plaintext, Map.put(query_params, "KeySpec", "AES_256"))
+    else
+      request(:generate_data_key_without_plaintext, query_params)
+    end
   end
 
   @doc "Generates an unpredictable byte string"

--- a/test/lib/kms_test.exs
+++ b/test/lib/kms_test.exs
@@ -481,6 +481,36 @@ defmodule ExAws.KMSTest do
                key_spec: "AES_128",
                number_of_bytes: 16
              )
+
+    operation_with_number_of_bytes =
+      ExAws.KMS.generate_data_key_without_plaintext("key-id",
+        encryption_context: %{"key" => "value"},
+        grant_tokens: ["token"],
+        number_of_bytes: 32
+      )
+
+    assert %ExAws.Operation.JSON{
+             before_request: nil,
+             data: %{
+               "Action" => "GenerateDataKeyWithoutPlaintext",
+               "Version" => @version,
+               "KeyId" => "key-id",
+               "EncryptionContext" => %{"key" => "value"},
+               "GrantTokens" => ["token"],
+               "NumberOfBytes" => 32
+             },
+             headers: [
+               {"x-amz-target", "TrentService.GenerateDataKeyWithoutPlaintext"},
+               {"content-type", "application/x-amz-json-1.0"}
+             ],
+             http_method: :post,
+             parser: _,
+             path: "/",
+             service: :kms,
+             stream_builder: nil
+           } = operation_with_number_of_bytes
+
+    refute operation_with_number_of_bytes.data["KeySpec"]
   end
 
   test "GenerateRandom" do


### PR DESCRIPTION
Thanks for your work on `ex_aws_kms`, I hope this contribution is helpful and I'd be grateful for any feedback on it.

## The Issue

I've run into an apparent issue when calling `ExAws.KMS.generate_data_key_without_plaintext(number_of_bytes: 128)`: the response returned is `{"ValidationException", "Please specify either number of bytes or key spec."}`. That function adds a default `"KeySpec"` even when `"NumberOfBytes"` is provided in the options. Per [the docs](https://docs.aws.amazon.com/kms/latest/APIReference/API_GenerateDataKeyWithoutPlaintext.html), AWS KMS expects a `"KeySpec"` or a `"NumberOfBytes"` but not both:

> You must also specify the length of the data key. Use either the KeySpec or NumberOfBytes parameters (but not both).

## The Fix

`ExAws.KMS.generate_data_key` avoids this issue by only adding the default `"KeySpec"` when `"NumberOfBytes"` is not given. This pull request applies that same approach to `ExAws.KMS.generate_data_key_without_plaintext` and adds a test to confirm it.