### PR TITLE
Allow passing rotation period when enabling key rotation

### DIFF
--- a/lib/ex_aws/kms.ex
+++ b/lib/ex_aws/kms.ex
@@ -169,11 +169,15 @@ defmodule ExAws.KMS do
 
   @doc "Enable a key rotation"
   @spec enable_key_rotation(key_id :: binary) :: ExAws.Operation.JSON.t()
-  def enable_key_rotation(key_id) do
+  @spec enable_key_rotation(key_id :: binary, rotation_period_in_days :: integer) ::
+          ExAws.Operation.JSON.t()
+  def enable_key_rotation(key_id, rotation_period_in_days \\ 365)
+      when rotation_period_in_days >= 90 and rotation_period_in_days <= 2560 do
     query_params = %{
       "Action" => "EnableKeyRotation",
       "Version" => @version,
-      "KeyId" => key_id
+      "KeyId" => key_id,
+      "RotationPeriodInDays" => rotation_period_in_days
     }
 
     request(:enable_key_rotation, query_params)

--- a/test/lib/kms_test.exs
+++ b/test/lib/kms_test.exs
@@ -242,7 +242,12 @@ defmodule ExAws.KMSTest do
   test "EnableKeyRotation" do
     assert %ExAws.Operation.JSON{
              before_request: nil,
-             data: %{"Action" => "EnableKeyRotation", "Version" => @version, "KeyId" => "key-id"},
+             data: %{
+               "Action" => "EnableKeyRotation",
+               "Version" => @version,
+               "KeyId" => "key-id",
+               "RotationPeriodInDays" => 365
+             },
              headers: [
                {"x-amz-target", "TrentService.EnableKeyRotation"},
                {"content-type", "application/x-amz-json-1.0"}
@@ -253,6 +258,25 @@ defmodule ExAws.KMSTest do
              service: :kms,
              stream_builder: nil
            } = ExAws.KMS.enable_key_rotation("key-id")
+
+    assert %ExAws.Operation.JSON{
+             before_request: nil,
+             data: %{
+               "Action" => "EnableKeyRotation",
+               "Version" => @version,
+               "KeyId" => "key-id",
+               "RotationPeriodInDays" => 90
+             },
+             headers: [
+               {"x-amz-target", "TrentService.EnableKeyRotation"},
+               {"content-type", "application/x-amz-json-1.0"}
+             ],
+             http_method: :post,
+             parser: _,
+             path: "/",
+             service: :kms,
+             stream_builder: nil
+           } = ExAws.KMS.enable_key_rotation("key-id", 90)
   end
 
   test "Encrypt" do


### PR DESCRIPTION
The `RotationPeriodInDays` parameter specifies the rotation period when enabling key rotation. When not set it defaults to 365 days. This change allows specifying the parameter and sets it to 365 explicitly if its not set.

https://docs.aws.amazon.com/kms/latest/APIReference/API_EnableKeyRotation.html#KMS-EnableKeyRotation-request-RotationPeriodInDays